### PR TITLE
Add functionality to add image to wine bottle with multer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package-lock.json
 *.log
 logs/
 dist/
+uploads/

--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ A backend API to manage winemakers and wine bottles with filtering and MongoDB s
 ## Environment Variables
 
 Create a `.env` file:
-MONGO_URI=<your-mongodb-uri>
-PORT=<your-port>
+
+- MONGO_URI=<your-mongodb-uri>
+- PORT=<your-port>

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "mongodb": "^6.12.0",
-    "mongoose": "^8.9.0"
+    "mongoose": "^8.9.0",
+    "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
+    "@types/multer": "^1.4.12",
     "@types/node": "^22.10.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.2"

--- a/src/controllers/wineBottleController.ts
+++ b/src/controllers/wineBottleController.ts
@@ -7,6 +7,7 @@ import {
   parseTastes,
   parseYears,
 } from "../utils/queryHelpers";
+import { Request, Response } from "express";
 
 const deleteWineBottle: RouteHandler = async (req, res) => {
   try {
@@ -116,10 +117,49 @@ const updateWineBottle: RouteHandler = async (req, res) => {
   }
 };
 
+const uploadWineBottleImage = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const bottleId = req.params.id;
+
+    // Ensure file was uploaded
+    if (!req.file) {
+      res.status(400).json({ error: "No image file uploaded." });
+      return;
+    }
+
+    // Find the wine bottle by ID
+    const wineBottle = await WineBottle.findById(bottleId);
+    if (!wineBottle) {
+      res.status(404).json({ error: "Wine bottle not found." });
+      return;
+    }
+
+    const imagePath = `uploads/${req.file.filename}`;
+    const imageURL = `${req.protocol}://${req.get("host")}/${imagePath}`;
+
+    // Update the wine bottle with image path and link
+    wineBottle.image = imagePath;
+    wineBottle.link = imageURL;
+
+    await wineBottle.save();
+
+    res.status(200).json({
+      message: "Image uploaded successfully to wine bottle.",
+      bottle: wineBottle,
+    });
+  } catch (error) {
+    handleErrors(res, error);
+  }
+};
+
 export {
+  deleteWineBottle,
   getWineBottles,
   getWineBottleById,
-  updateWineBottle,
   postWineBottle,
-  deleteWineBottle,
+  updateWineBottle,
+  uploadWineBottleImage,
 };

--- a/src/routes/wineBottleRoutes.ts
+++ b/src/routes/wineBottleRoutes.ts
@@ -5,7 +5,9 @@ import {
   updateWineBottle,
   postWineBottle,
   deleteWineBottle,
+  uploadWineBottleImage,
 } from "../controllers/wineBottleController";
+import { upload } from "../utils/fileUploader";
 
 const router = Router();
 
@@ -13,6 +15,7 @@ router.delete("/:id", deleteWineBottle);
 router.get("/", getWineBottles);
 router.get("/:id", getWineBottleById);
 router.post("/", postWineBottle);
+router.post("/:id/image", upload.single("image"), uploadWineBottleImage);
 router.put("/:id", updateWineBottle);
 
 export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,8 @@ app.get("/health", (req, res) => {
 // Routes
 app.use("/winemakers", winemakerRoutes);
 app.use("/bottles", wineBottleRoutes);
+app.use('/uploads', express.static('uploads'));
+
 
 // Connect to MongoDB Atlas
 const MONGO_URI = process.env.MONGO_URI as string;

--- a/src/utils/fileUploader.ts
+++ b/src/utils/fileUploader.ts
@@ -1,0 +1,35 @@
+import multer from "multer";
+import path from "path";
+
+// Multer Storage Configuration
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, "uploads/"); // Uploads folder at the project root
+  },
+  filename: (req, file, cb) => {
+    // Add timestamp to the file name to avoid overwrites
+    cb(null, `${Date.now()}${path.extname(file.originalname)}`);
+  },
+});
+
+// File filter for image types
+const fileFilter = (req: any, file: any, cb: any) => {
+  const allowedTypes = /jpeg|jpg|png/;
+  const extName = allowedTypes.test(
+    path.extname(file.originalname).toLowerCase()
+  );
+  const mimeType = allowedTypes.test(file.mimetype);
+
+  if (extName && mimeType) {
+    cb(null, true);
+  } else {
+    cb(new Error("Only JPEG, JPG, and PNG files are allowed."));
+  }
+};
+
+// Initialize Multer
+export const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB file size limit
+  fileFilter,
+});


### PR DESCRIPTION
## Description

Implements the ability to upload images for wine bottles and store their corresponding public URLs in the "link" attribute. Images are uploaded to the server's local file system (uploads/ directory), and a dynamically generated link is saved in the database for easy access.

## To Test 
1. Open Postman
2. Send GET request to `http://localhost:3000/bottles` and choose an bottle ID
3. Send POST request to `http://localhost:3000/bottles/:id/image`
4. In Body tab, choose 'Form Data'. For 'Key' put 'image'. For 'Value' upload a .jpg, .jpeg or .png file
5. Verify response. Copy link into browser, ensure you see image. 

## Additional Notes
- The uploads/ folder has been added to .gitignore to prevent uploaded files from being committed.
- Consider implementing file clean-up logic in the future to avoid unused files accumulating.